### PR TITLE
declare artifact_content variable to avoid reference before assignmen…

### DIFF
--- a/turbinia/workers/analysis/llm_analyzer.py
+++ b/turbinia/workers/analysis/llm_analyzer.py
@@ -105,6 +105,7 @@ class LLMAnalyzerTask(workers.TurbiniaTask):
       open_function = gzip.open
 
     # Read the input file
+    artifact_content = None
     try:
       with open_function(evidence.local_path, "rb") as input_file:
         artifact_content = input_file.read().decode("utf-8")


### PR DESCRIPTION
…t in case of exception

in case the content is not UTF-8 encoded an exception will be raised and artifact_content will never be assigned, this cause the task to fail with a misleading exception: `[local variable 'artifact_content' referenced before assignment]`, while it should be `Artifact {evidence.artifact_name} has empty content or not UTF-8 encoded`